### PR TITLE
Set repository.url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby-starter-hello-world"
+    "url": "https://github.com/open-olive/olive-helps"
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"


### PR DESCRIPTION
E.g. so that `npm repo` will work to browse to the repo on GH.