### PR TITLE
[SIDE-884] Remove Linux URL, Add .Net URL

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,19 +5,44 @@ import "./index.scss"
 import { PageHeader } from "../components/page-header"
 import OliveHelpsLogo from "../components/olive-helps-logo"
 import {
+  dotNetLDKUrl,
   downloadMacUrl,
   downloadWindowsUrl,
   goGitHubUrl,
   goLDKUrl,
   nodeGitHubUrl,
-  nodeLDKUrl,
 } from "../references"
 import { Section } from "../components/section"
+
+interface LanguageBlockProps {
+  language: string
+  repoURL: string
+  docURL?: string
+  docURLNotice?: string
+}
+
+const LanguageBlock: React.FunctionComponent<LanguageBlockProps> = props => (
+  <article className={styles.downloadItem}>
+    <h3 className={styles.languageTitle}>{props.language}</h3>
+    <a href={props.repoURL} className={styles.ldkLink}>
+      GitHub
+    </a>
+    <br />
+    {props.docURL && (
+      <a href={props.docURL} className={styles.ldkLink}>
+        Documentation
+      </a>
+    )}
+    {props.docURLNotice && (
+      <span className={styles.ldkLink}>{props.docURLNotice}</span>
+    )}
+  </article>
+)
 
 export default function Home() {
   const title = (
     <>
-      <OliveHelpsLogo className={styles.headerImage}/> <br />
+      <OliveHelpsLogo className={styles.headerImage} /> <br />
       Developer Hub
     </>
   )
@@ -44,26 +69,17 @@ export default function Home() {
         <h2 className={styles.sectionTitle}>Get the LDK</h2>
         <p>Get the LDK and start building!</p>
         <div className={styles.downloadCollection}>
-          <article className={styles.downloadItem}>
-            <h3 className={styles.languageTitle}>Node</h3>
-            <a href={nodeGitHubUrl} className={styles.ldkLink}>
-              GitHub
-            </a>
-            <br />
-            <a href={nodeLDKUrl} className={styles.ldkLink}>
-              Documentation
-            </a>
-          </article>
-          <article className={styles.downloadItem}>
-            <h3 className={styles.languageTitle}>Go</h3>
-            <a href={goGitHubUrl} className={styles.ldkLink}>
-              GitHub
-            </a>
-            <br />
-            <a href={goLDKUrl} className={styles.ldkLink}>
-              Documentation
-            </a>
-          </article>
+          <LanguageBlock
+            language="Go"
+            repoURL={goGitHubUrl}
+            docURL={goLDKUrl}
+          />
+          <LanguageBlock language=".Net" repoURL={dotNetLDKUrl} />
+          <LanguageBlock
+            language="Node"
+            repoURL={nodeGitHubUrl}
+            docURLNotice="Documentation Coming Soon!"
+          />
         </div>
       </Section>
       <Section>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,6 @@ import "./index.scss"
 import { PageHeader } from "../components/page-header"
 import OliveHelpsLogo from "../components/olive-helps-logo"
 import {
-  downloadLinuxUrl,
   downloadMacUrl,
   downloadWindowsUrl,
   goGitHubUrl,
@@ -37,11 +36,6 @@ export default function Home() {
           <article className={styles.downloadItem}>
             <a className={styles.downloadLink} href={downloadMacUrl}>
               MacOS
-            </a>
-          </article>
-          <article className={styles.downloadItem}>
-            <a className={styles.downloadLink} href={downloadLinuxUrl}>
-              Linux
             </a>
           </article>
         </div>

--- a/src/references.ts
+++ b/src/references.ts
@@ -1,5 +1,4 @@
 export const downloadWindowsUrl = "https://olive.page.link/olive-helps-windows"
-export const downloadLinuxUrl = "https://olive.page.link/olive-helps-linux"
 export const downloadMacUrl = "https://olive.page.link/olive-helps-mac"
 export const nodeGitHubUrl =
   "https://github.com/open-olive/loop-development-kit-node"

--- a/src/references.ts
+++ b/src/references.ts
@@ -1,10 +1,11 @@
 export const downloadWindowsUrl = "https://olive.page.link/olive-helps-windows"
 export const downloadMacUrl = "https://olive.page.link/olive-helps-mac"
 export const nodeGitHubUrl =
-  "https://github.com/open-olive/loop-development-kit-node"
+  "https://github.com/open-olive/loop-development-kit/tree/main/ldk/node"
 export const goGitHubUrl =
-  "https://github.com/open-olive/loop-development-kit-go"
+  "https://github.com/open-olive/loop-development-kit/tree/main/ldk/go"
 export const nodeLDKUrl =
   "https://open-olive.github.io/loop-development-kit-node/"
 export const goLDKUrl =
-  "https://pkg.go.dev/github.com/open-olive/loop-development-kit-go"
+  "https://pkg.go.dev/github.com/open-olive/loop-development-kit/ldk/go"
+export const dotNetLDKUrl = "https://github.com/open-olive/loop-development-kit/tree/main/ldk/csharp/OliveHelpsLDK"


### PR DESCRIPTION
This PR removes the Linux build URL, adds the .Net Repo URL, and updates the other URLs..

Node LDK docs aren't building right at this time so I've left them as coming soon until I fix that in the next ticket (SIDE-986)